### PR TITLE
Fix value padding in FITSHeader::new()



### DIFF
--- a/src/hdu/data.rs
+++ b/src/hdu/data.rs
@@ -1,4 +1,4 @@
-const PADDING: u8 = 32;
+const NULL_BYTE: u8 = 0;
 
 use crate::fill_to_2880;
 
@@ -15,7 +15,7 @@ impl FITSData {
         let bytes_to_add = fill_to_2880(data.len() as i32);
 
         for _ in 0..bytes_to_add {
-            data.push(PADDING);
+            data.push(NULL_BYTE);
         }
 
         self.data = data;
@@ -36,6 +36,7 @@ mod tests {
         let mut fits_data = FITSData::new();
         fits_data.add(image);
         assert_eq!(fits_data.data.len(), 480_960);
+        assert_eq!(fits_data.data[480_000], 0u8);
     }
 
     #[test]

--- a/src/hdu/headers.rs
+++ b/src/hdu/headers.rs
@@ -67,7 +67,7 @@ impl FITSHeader {
             header_value[i] = *char;
         }
 
-        for i in key.len()..70 {
+        for i in value.len()..70 {
             header_value[i as usize] = PADDING;
         }
 
@@ -172,6 +172,23 @@ mod tests {
 
         assert_eq!(header_key, key);
         assert_eq!(header_value, value);
+    }
+
+    #[test]
+    fn value_not_truncated_when_longer_than_key() {
+        // key.len() == 2, value.len() == 3; the old bug used key.len() as the
+        // padding start index, which overwrote the last byte of the value with
+        // a space.
+        let header = FITSHeader::new("AB", "FOO");
+        let value_str = std::str::from_utf8(&header.value).unwrap();
+        assert!(
+            value_str.starts_with("FOO"),
+            "expected value to start with 'FOO', got: {:?}",
+            &value_str[..10]
+        );
+        assert_eq!(value_str.len(), 70);
+        // The remaining 67 bytes must all be spaces
+        assert_eq!(&value_str[3..], " ".repeat(67));
     }
 
     #[test]


### PR DESCRIPTION
Fix value padding in FITSHeader::new() to use value.len() instead of key.len()
The padding loop that fills unused bytes of the value field with spaces
was starting from key.len() instead of value.len(). When the value is
longer than the key, this caused the tail bytes of the value to be
overwritten with spaces.

Also adds a regression test (value_not_truncated_when_longer_than_key)
using key="AB" (len 2) and value="FOO" (len 3) to verify the full value
is preserved followed by exactly 67 padding spaces.