### PR TITLE
Implement remaining FITS spec compliance

### DIFF
--- a/src/hdu/data.rs
+++ b/src/hdu/data.rs
@@ -8,17 +8,51 @@ pub struct FITSData {
 
 impl FITSData {
     pub fn new() -> FITSData {
-        return FITSData { data: Vec::new() };
+        FITSData { data: Vec::new() }
     }
 
+    /// Store raw pixel bytes and pad to the next 2880-byte boundary with null bytes.
     pub fn add(&mut self, mut data: Vec<u8>) {
         let bytes_to_add = fill_to_2880(data.len() as i32);
-
         for _ in 0..bytes_to_add {
             data.push(NULL_BYTE);
         }
-
         self.data = data;
+    }
+
+    /// Store `u8` pixels (BITPIX = 8).  No byte-swapping needed for single bytes.
+    pub fn add_u8(&mut self, values: &[u8]) {
+        self.add(values.to_vec());
+    }
+
+    /// Store `i16` pixels (BITPIX = 16) in FITS big-endian byte order.
+    pub fn add_i16(&mut self, values: &[i16]) {
+        let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_be_bytes()).collect();
+        self.add(bytes);
+    }
+
+    /// Store `i32` pixels (BITPIX = 32) in FITS big-endian byte order.
+    pub fn add_i32(&mut self, values: &[i32]) {
+        let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_be_bytes()).collect();
+        self.add(bytes);
+    }
+
+    /// Store `i64` pixels (BITPIX = 64) in FITS big-endian byte order.
+    pub fn add_i64(&mut self, values: &[i64]) {
+        let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_be_bytes()).collect();
+        self.add(bytes);
+    }
+
+    /// Store `f32` pixels (BITPIX = -32) in FITS big-endian byte order.
+    pub fn add_f32(&mut self, values: &[f32]) {
+        let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_be_bytes()).collect();
+        self.add(bytes);
+    }
+
+    /// Store `f64` pixels (BITPIX = -64) in FITS big-endian byte order.
+    pub fn add_f64(&mut self, values: &[f64]) {
+        let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_be_bytes()).collect();
+        self.add(bytes);
     }
 }
 
@@ -26,10 +60,7 @@ impl FITSData {
 mod tests {
     use crate::hdu::data::FITSData;
 
-    // In this test we are simulating adding an image which is
-    // 480_000 (800px*600px) bytes long. 480_000 is not a multiple
-    // of 2880 so we expect to add 960 additional bytes to fulfill
-    // the FITS spec
+    // 800×600 px image: 480_000 bytes, not a multiple of 2880 → 960 padding bytes
     #[test]
     fn correct_unit_length() {
         let image = vec![255; 800 * 600];
@@ -45,5 +76,27 @@ mod tests {
         let mut fits_data = FITSData::new();
         fits_data.add(image);
         assert_eq!(fits_data.data.len(), 2880);
+    }
+
+    #[test]
+    fn add_i16_stores_big_endian() {
+        let pixels: Vec<i16> = vec![256, -1];
+        let mut fits_data = FITSData::new();
+        fits_data.add_i16(&pixels);
+        // 256 big-endian = [0x01, 0x00]
+        assert_eq!(fits_data.data[0], 0x01);
+        assert_eq!(fits_data.data[1], 0x00);
+        // -1 big-endian = [0xFF, 0xFF]
+        assert_eq!(fits_data.data[2], 0xFF);
+        assert_eq!(fits_data.data[3], 0xFF);
+    }
+
+    #[test]
+    fn add_f32_stores_big_endian() {
+        let pixels: Vec<f32> = vec![1.0_f32];
+        let mut fits_data = FITSData::new();
+        fits_data.add_f32(&pixels);
+        // 1.0f32 big-endian IEEE 754 = [0x3F, 0x80, 0x00, 0x00]
+        assert_eq!(&fits_data.data[..4], &[0x3F, 0x80, 0x00, 0x00]);
     }
 }

--- a/src/hdu/headers.rs
+++ b/src/hdu/headers.rs
@@ -1,203 +1,351 @@
-//! Fast and easy queue abstraction.
-//!
-//! Provides an abstraction over a queue.  When the abstraction is used
-//! there are these advantages:
-//! - Fast
-//! - [`Easy`]
-//!
-//! [`Easy`]: http://thatwaseasy.example.com
-
-/// This module makes it easy.
-
 const PADDING: u8 = 32;
 const EQUAL_SIGN: u8 = 61;
 const END_HEADER_KEY: [u8; 10] = [69, 78, 68, 32, 32, 32, 32, 32, 32, 32];
 
-/// The representation of a FITS header, this is
-/// spec compliant.
+/// Typed FITS header value.
+///
+/// FITS encodes values with strict formatting rules:
+/// - `Logical` → `T` or `F`, right-justified in columns 11–30.
+/// - `Integer`  → right-justified in columns 11–30.
+/// - `Float`    → scientific notation, right-justified in columns 11–30.
+/// - `Text`     → enclosed in single quotes, padded to a minimum of 8 chars.
+pub enum FITSValue {
+    Logical(bool),
+    Integer(i64),
+    Float(f64),
+    Text(String),
+}
+
+/// The representation of a FITS header record (80 bytes total):
+/// - `key`   : 10 bytes — 8-char keyword + `=` + space (or all spaces for COMMENT/HISTORY/END)
+/// - `value` : 70 bytes — encoded value and optional inline comment
 pub struct FITSHeader {
     pub key: [u8; 10],
     pub value: [u8; 70],
 }
 
+/// Validate a FITS keyword:
+/// - 1–8 characters
+/// - Uppercase A–Z, digits 0–9, hyphen `-`, or underscore `_` only
+/// - `END`, `COMMENT`, `HISTORY` are reserved and must use their own constructors
+fn validate_keyword(key: &str) {
+    assert!(
+        !key.is_empty() && key.len() <= 8,
+        "FITS keyword must be 1–8 characters, got {:?}",
+        key
+    );
+    assert_ne!(
+        key, "END",
+        "END is reserved; use FITSHeader::end_hdu() instead"
+    );
+    assert_ne!(
+        key, "COMMENT",
+        "COMMENT records must be created with FITSHeader::comment()"
+    );
+    assert_ne!(
+        key, "HISTORY",
+        "HISTORY records must be created with FITSHeader::history()"
+    );
+    for c in key.chars() {
+        assert!(
+            matches!(c, 'A'..='Z' | '0'..='9' | '-' | '_'),
+            "invalid keyword character {:?}; only A\u{2013}Z, 0\u{2013}9, '-', '_' are allowed",
+            c
+        );
+    }
+}
+
+/// Encode a `FITSValue` (and optional inline comment) into the 70-byte value field.
+///
+/// Value field layout (FITS spec §4.2):
+/// - Logical / Integer / Float: right-justified in the first 20 bytes (columns 11–30).
+/// - Text: `'<string>'` left-aligned, string padded to at least 8 chars inside quotes.
+/// - Optional comment: ` / <text>` appended after the value, space-padded to 70 bytes.
+fn encode_value(value: FITSValue, comment: Option<&str>) -> [u8; 70] {
+    let val_str = match value {
+        FITSValue::Logical(b) => format!("{:>20}", if b { "T" } else { "F" }),
+        FITSValue::Integer(n) => format!("{:>20}", n),
+        FITSValue::Float(f) => format!("{:>20.10E}", f),
+        FITSValue::Text(ref s) => {
+            assert!(
+                s.len() <= 68,
+                "FITS string value too long (max 68 chars), got {} chars",
+                s.len()
+            );
+            // Internal single quotes are escaped by doubling them.
+            let escaped = s.replace('\'', "''");
+            // String content inside quotes must be at least 8 chars wide.
+            let padded_len = escaped.len().max(8);
+            format!("'{:<width$}'", escaped, width = padded_len)
+        }
+    };
+
+    let full = match comment {
+        Some(c) if !c.is_empty() => format!("{} / {}", val_str, c),
+        _ => val_str,
+    };
+
+    let mut result = [PADDING; 70];
+    for (i, b) in full.as_bytes().iter().take(70).enumerate() {
+        result[i] = *b;
+    }
+    result
+}
+
 impl FITSHeader {
-    /// Use this method if you are looking for extra performance
-    /// or you are reading an existing FITS file.
-    /// DRAGONS AHEAD: This method usese memcpy so the incoming array
-    /// must be the same size of the one where it will be copied; if
-    /// this contract is not mantained the process will panic.
+    /// Fast path for reading existing FITS files. The incoming slices must be
+    /// exactly 10 bytes (key field) and 70 bytes (value field) respectively.
     pub fn new_raw(key: &[u8], value: &[u8]) -> FITSHeader {
         let mut header_key = [0; 10];
         let mut header_value = [0; 70];
-
         header_key.copy_from_slice(key);
         header_value.copy_from_slice(value);
-
         FITSHeader {
             key: header_key,
             value: header_value,
         }
     }
 
-    pub fn new(key: &str, value: &str) -> FITSHeader {
-        match key.len() {
-            1..=8 => (),
-            _ => panic!("KEY for the header is too long"),
-        };
-
-        match value.len() {
-            1..=70 => (),
-            _ => panic!("VALUE for the header is too long"),
-        };
-
-        let mut header_key = [0; 10];
-        let mut header_value = [0; 70];
-
-        for (i, char) in key.as_bytes().into_iter().enumerate() {
-            header_key[i] = *char;
+    /// Create a valued FITS header keyword.
+    ///
+    /// `key` must be 1–8 uppercase characters (A–Z, 0–9, `-`, `_`).
+    /// The value is encoded according to FITS spec formatting rules.
+    pub fn new(key: &str, value: FITSValue) -> FITSHeader {
+        validate_keyword(key);
+        let mut header_key = [PADDING; 10];
+        for (i, b) in key.as_bytes().iter().enumerate() {
+            header_key[i] = *b;
         }
+        header_key[8] = EQUAL_SIGN;
+        // header_key[9] stays PADDING (space)
 
-        for i in key.len()..10 {
-            header_key[i as usize] = PADDING;
+        FITSHeader {
+            key: header_key,
+            value: encode_value(value, None),
         }
+    }
 
+    /// Create a valued FITS header keyword with an inline comment.
+    pub fn new_with_comment(key: &str, value: FITSValue, comment: &str) -> FITSHeader {
+        validate_keyword(key);
+        let mut header_key = [PADDING; 10];
+        for (i, b) in key.as_bytes().iter().enumerate() {
+            header_key[i] = *b;
+        }
         header_key[8] = EQUAL_SIGN;
 
-        for (i, char) in value.as_bytes().into_iter().enumerate() {
-            header_value[i] = *char;
-        }
-
-        for i in value.len()..70 {
-            header_value[i as usize] = PADDING;
-        }
-
         FITSHeader {
             key: header_key,
-            value: header_value,
+            value: encode_value(value, Some(comment)),
         }
     }
 
-    /// With this method the HDU ending header will be constructed,
-    /// according to the FITS spec it started with END, doesn't
-    /// contain an = sign and is padded till the end of the 80 bytes
-    /// long hdu block.
-    pub fn end_hdu() -> FITSHeader {
-        let value = [PADDING; 70];
+    /// Create a `COMMENT` record. COMMENT records have no `=` indicator;
+    /// up to 70 chars of free-form ASCII text fill the value field.
+    pub fn comment(text: &str) -> FITSHeader {
+        let mut key = [PADDING; 10];
+        for (i, b) in b"COMMENT".iter().enumerate() {
+            key[i] = *b;
+        }
+        // Positions 8 and 9 remain spaces — no `=` for COMMENT records.
 
+        let mut value = [PADDING; 70];
+        for (i, b) in text.as_bytes().iter().take(70).enumerate() {
+            value[i] = *b;
+        }
+        FITSHeader { key, value }
+    }
+
+    /// Create a `HISTORY` record. Like COMMENT, no `=` indicator is used.
+    pub fn history(text: &str) -> FITSHeader {
+        let mut key = [PADDING; 10];
+        for (i, b) in b"HISTORY".iter().enumerate() {
+            key[i] = *b;
+        }
+
+        let mut value = [PADDING; 70];
+        for (i, b) in text.as_bytes().iter().take(70).enumerate() {
+            value[i] = *b;
+        }
+        FITSHeader { key, value }
+    }
+
+    /// Create the mandatory `END` keyword that terminates a header section.
+    /// Per FITS spec, END has no `=` and is padded with spaces to 80 bytes.
+    pub fn end_hdu() -> FITSHeader {
         FITSHeader {
             key: END_HEADER_KEY,
-            value: value,
+            value: [PADDING; 70],
         }
     }
 
     pub fn key_as_str(&self) -> &str {
-        return std::str::from_utf8(&self.key).unwrap();
+        std::str::from_utf8(&self.key).unwrap()
     }
 
     pub fn value_as_str(&self) -> &str {
-        return std::str::from_utf8(&self.value).unwrap();
+        std::str::from_utf8(&self.value).unwrap()
     }
 
     pub fn as_str(&self) -> String {
-        let repr = format!("{}{}", self.key_as_str(), self.value_as_str());
-        return repr;
+        format!("{}{}", self.key_as_str(), self.value_as_str())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::hdu::headers::FITSHeader;
+    use super::{FITSHeader, FITSValue};
+
+    // --- key format ---
 
     #[test]
     fn correct_key_format() {
-        let header = FITSHeader::new("FOO", "BAR");
+        let header = FITSHeader::new("FOO", FITSValue::Integer(1));
         assert_eq!(std::str::from_utf8(&header.key).unwrap(), "FOO     = ");
     }
 
     #[test]
     fn correct_key_length() {
-        let header = FITSHeader::new("FOO", "BAR");
+        let header = FITSHeader::new("FOO", FITSValue::Integer(1));
         assert_eq!(header.key.len(), 10);
     }
 
+    // --- value encoding ---
+
     #[test]
-    fn correct_value_format() {
-        let header = FITSHeader::new("FOO", "BAR");
-        assert_eq!(
-            std::str::from_utf8(&header.value).unwrap(),
-            "BAR                                                                   "
+    fn integer_value_right_justified() {
+        let header = FITSHeader::new("NAXIS", FITSValue::Integer(2));
+        assert_eq!(&header.value_as_str()[..20], "                   2");
+    }
+
+    #[test]
+    fn logical_true_right_justified() {
+        let header = FITSHeader::new("SIMPLE", FITSValue::Logical(true));
+        assert_eq!(&header.value_as_str()[..20], "                   T");
+    }
+
+    #[test]
+    fn logical_false_right_justified() {
+        let header = FITSHeader::new("SIMPLE", FITSValue::Logical(false));
+        assert_eq!(&header.value_as_str()[..20], "                   F");
+    }
+
+    #[test]
+    fn text_value_single_quoted_padded_to_8() {
+        let header = FITSHeader::new("TELESCOP", FITSValue::Text("HST".into()));
+        // Minimum 8 chars inside quotes → 'HST     '
+        assert!(
+            header.value_as_str().starts_with("'HST     '"),
+            "got: {:?}",
+            &header.value_as_str()[..12]
         );
     }
 
     #[test]
-    fn correct_value_length() {
-        let header = FITSHeader::new("FOO", "BAR");
+    fn text_value_internal_quote_doubled() {
+        let header = FITSHeader::new("ORIGIN", FITSValue::Text("O'Hara".into()));
+        assert!(
+            header.value_as_str().starts_with("'O''Hara '"),
+            "got: {:?}",
+            &header.value_as_str()[..12]
+        );
+    }
+
+    #[test]
+    fn float_value_scientific_notation() {
+        let header = FITSHeader::new("EXPTIME", FITSValue::Float(1.5e3));
+        let trimmed = header.value_as_str()[..20].trim();
+        assert!(
+            trimmed.contains('E'),
+            "expected scientific notation in {:?}",
+            trimmed
+        );
+    }
+
+    #[test]
+    fn value_with_comment() {
+        let header = FITSHeader::new_with_comment(
+            "BITPIX",
+            FITSValue::Integer(16),
+            "bits per pixel",
+        );
+        assert!(
+            header.value_as_str().contains("/ bits per pixel"),
+            "got: {:?}",
+            &header.value_as_str()[..40]
+        );
+    }
+
+    #[test]
+    fn value_field_is_70_bytes() {
+        let header = FITSHeader::new("NAXIS1", FITSValue::Integer(1024));
         assert_eq!(header.value.len(), 70);
     }
 
     #[test]
-    fn correct_key_representation() {
-        let header = FITSHeader::new("FOO", "BAR");
-        let key = header.key_as_str();
+    fn value_not_truncated_when_longer_than_key() {
+        let header = FITSHeader::new("AB", FITSValue::Text("LONGERVAL".into()));
+        assert!(
+            header.value_as_str().contains("LONGERVAL"),
+            "value was truncated: {:?}",
+            &header.value_as_str()[..20]
+        );
+    }
 
-        assert_eq!(key.contains("FOO"), true);
-        assert_eq!(key.contains("="), true);
+    // --- COMMENT / HISTORY ---
+
+    #[test]
+    fn comment_record_has_no_equals() {
+        let header = FITSHeader::comment("written by rfitsio");
+        assert!(!header.key_as_str().contains('='));
+        assert!(header.value_as_str().starts_with("written by rfitsio"));
     }
 
     #[test]
-    fn correct_value_representation() {
-        let header = FITSHeader::new("FOO", "BAR");
-        let value = header.value_as_str();
+    fn history_record_has_no_equals() {
+        let header = FITSHeader::history("calibrated 2024-01-01");
+        assert!(!header.key_as_str().contains('='));
+        assert!(header.value_as_str().starts_with("calibrated 2024-01-01"));
+    }
 
-        assert_eq!(value.contains("BAR"), true);
+    // --- END keyword ---
+
+    #[test]
+    fn check_end_header_constructed_correctly() {
+        let header = FITSHeader::end_hdu();
+        assert!(header.key_as_str().contains("END"));
+        assert!(!header.key_as_str().contains('='));
+        assert_eq!(header.value, [32; 70]);
+    }
+
+    // --- keyword validation ---
+
+    #[test]
+    #[should_panic(expected = "only A")]
+    fn lowercase_keyword_rejected() {
+        FITSHeader::new("simple", FITSValue::Logical(true));
     }
 
     #[test]
-    fn correct_full_representation() {
-        let header = FITSHeader::new("FOO", "BAR");
-        let full_header = header.as_str();
-
-        assert_eq!(full_header.contains("FOO"), true);
-        assert_eq!(full_header.contains("BAR"), true);
-        assert_eq!(full_header.contains("="), true);
+    #[should_panic(expected = "reserved")]
+    fn end_keyword_rejected_via_new() {
+        FITSHeader::new("END", FITSValue::Logical(true));
     }
+
+    #[test]
+    #[should_panic(expected = "1")]
+    fn keyword_too_long_rejected() {
+        FITSHeader::new("TOOLONGKEY", FITSValue::Integer(0));
+    }
+
+    // --- new_raw ---
 
     #[test]
     fn new_raw_built_correctly() {
         let key = "COOL    = ";
         let value = "          AWESOME VALUE  / COMMENT                                    ";
         let header = FITSHeader::new_raw(key.as_bytes(), value.as_bytes());
-        let header_value = header.value_as_str();
-        let header_key = header.key_as_str();
-
-        assert_eq!(header_key, key);
-        assert_eq!(header_value, value);
-    }
-
-    #[test]
-    fn value_not_truncated_when_longer_than_key() {
-        // key.len() == 2, value.len() == 3; the old bug used key.len() as the
-        // padding start index, which overwrote the last byte of the value with
-        // a space.
-        let header = FITSHeader::new("AB", "FOO");
-        let value_str = std::str::from_utf8(&header.value).unwrap();
-        assert!(
-            value_str.starts_with("FOO"),
-            "expected value to start with 'FOO', got: {:?}",
-            &value_str[..10]
-        );
-        assert_eq!(value_str.len(), 70);
-        // The remaining 67 bytes must all be spaces
-        assert_eq!(&value_str[3..], " ".repeat(67));
-    }
-
-    #[test]
-    fn check_end_header_constructed_correctly() {
-        let header = FITSHeader::end_hdu();
-        let header_key = header.key_as_str();
-
-        assert_eq!(header_key.contains("END"), true);
-        assert_eq!(header_key.contains("="), false);
-        assert_eq!(header.value, [32; 70]);
+        assert_eq!(header.key_as_str(), key);
+        assert_eq!(header.value_as_str(), value);
     }
 }

--- a/src/hdu/mod.rs
+++ b/src/hdu/mod.rs
@@ -1,50 +1,125 @@
 pub mod data;
 pub mod headers;
 
+use crate::fill_to_2880;
 use crate::hdu::data::FITSData;
-use crate::hdu::headers::FITSHeader;
+use crate::hdu::headers::{FITSHeader, FITSValue};
 
 pub struct HDU {
     pub headers: Vec<FITSHeader>,
-    data: FITSData,
+    pub data: FITSData,
 }
 
 impl HDU {
-    fn init() -> HDU {
-        return HDU {
+    pub fn init() -> HDU {
+        HDU {
             headers: Vec::new(),
             data: FITSData::new(),
-        };
+        }
     }
 
-    fn raw_data(&self) -> &Vec<u8> {
+    pub fn raw_data(&self) -> &Vec<u8> {
         &self.data.data
     }
 
-    fn add_data(&mut self, data: Vec<u8>) {
+    pub fn add_data(&mut self, data: Vec<u8>) {
         self.data.add(data);
     }
 
-    fn add_header(&mut self, key: &str, value: &str) {
-        let header = FITSHeader::new(key, value);
-        self.headers.push(header);
+    pub fn add_header(&mut self, key: &str, value: FITSValue) {
+        self.headers.push(FITSHeader::new(key, value));
+    }
+
+    pub fn add_header_with_comment(&mut self, key: &str, value: FITSValue, comment: &str) {
+        self.headers
+            .push(FITSHeader::new_with_comment(key, value, comment));
+    }
+
+    pub fn add_comment(&mut self, text: &str) {
+        self.headers.push(FITSHeader::comment(text));
+    }
+
+    pub fn add_history(&mut self, text: &str) {
+        self.headers.push(FITSHeader::history(text));
+    }
+
+    /// Validate this HDU as a primary HDU (the first HDU in a FITS file).
+    ///
+    /// Per FITS spec the primary HDU must have:
+    /// - `SIMPLE` as the first keyword
+    /// - `BITPIX` present
+    /// - `NAXIS` present
+    /// - `END` as the last keyword
+    pub fn validate_primary(&self) -> Result<(), String> {
+        if self.headers.is_empty() {
+            return Err("primary HDU has no headers".into());
+        }
+
+        if &self.headers[0].key[..6] != b"SIMPLE" {
+            return Err(format!(
+                "first keyword must be SIMPLE, found: {}",
+                std::str::from_utf8(&self.headers[0].key[..6]).unwrap_or("?")
+            ));
+        }
+
+        let has_bitpix = self
+            .headers
+            .iter()
+            .any(|h| &h.key[..6] == b"BITPIX");
+        if !has_bitpix {
+            return Err("BITPIX keyword is required in the primary HDU".into());
+        }
+
+        let has_naxis = self
+            .headers
+            .iter()
+            .any(|h| &h.key[..5] == b"NAXIS" && h.key[5] == b' ');
+        if !has_naxis {
+            return Err("NAXIS keyword is required in the primary HDU".into());
+        }
+
+        if &self.headers.last().unwrap().key[..3] != b"END" {
+            return Err("last keyword must be END".into());
+        }
+
+        Ok(())
+    }
+
+    /// Serialize this HDU to a byte vector suitable for writing to a FITS file.
+    ///
+    /// - Header records are written as 80-byte blocks, then padded with spaces
+    ///   to the next 2880-byte boundary.
+    /// - Data bytes follow (already padded with null bytes by `FITSData::add`).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        for header in &self.headers {
+            bytes.extend_from_slice(&header.key);
+            bytes.extend_from_slice(&header.value);
+        }
+
+        // Pad the header section to the next 2880-byte boundary with spaces.
+        let header_padding = fill_to_2880(bytes.len() as i32) as usize;
+        bytes.extend(vec![b' '; header_padding]);
+
+        // Data is already null-padded by FITSData::add().
+        bytes.extend_from_slice(&self.data.data);
+
+        bytes
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::hdu::HDU;
+    use crate::hdu::{headers::FITSValue, HDU};
 
-    // Test that the HDU object is initialized correctly
     #[test]
     fn check_initialization() {
         let hdu = HDU::init();
-        assert_eq!(hdu.headers.is_empty(), true);
-        assert_eq!(hdu.raw_data().is_empty(), true);
+        assert!(hdu.headers.is_empty());
+        assert!(hdu.raw_data().is_empty());
     }
 
-    // Make sure that add_data method actually adds the image
-    // to the struct
     #[test]
     fn check_raw_data() {
         let mut hdu = HDU::init();
@@ -53,17 +128,58 @@ mod tests {
         assert_eq!(hdu.raw_data().len(), 2880);
     }
 
-    // Make sure that add_headermethod actually adds the header
-    // to `headers`
     #[test]
     fn check_adding_header() {
         let mut hdu = HDU::init();
-        hdu.add_header("NEW", "FOO");
-        let header = &hdu.headers[0];
-        let key = header.key_as_str();
-        let value = header.value_as_str();
+        hdu.add_header("NAXIS", FITSValue::Integer(2));
+        let key = hdu.headers[0].key_as_str();
+        let value = hdu.headers[0].value_as_str();
+        assert!(key.contains("NAXIS"));
+        assert!(value.contains('2'));
+    }
 
-        assert_eq!(key.contains("NEW"), true);
-        assert_eq!(value.contains("FOO"), true);
+    #[test]
+    fn to_bytes_header_section_multiple_of_2880() {
+        let mut hdu = HDU::init();
+        hdu.add_header("SIMPLE", FITSValue::Logical(true));
+        hdu.add_header("BITPIX", FITSValue::Integer(8));
+        hdu.add_header("NAXIS", FITSValue::Integer(0));
+        hdu.headers.push(crate::hdu::headers::FITSHeader::end_hdu());
+        let bytes = hdu.to_bytes();
+        assert_eq!(bytes.len() % 2880, 0, "serialized HDU must be a multiple of 2880 bytes");
+    }
+
+    #[test]
+    fn validate_primary_passes_for_valid_hdu() {
+        let mut hdu = HDU::init();
+        hdu.add_header("SIMPLE", FITSValue::Logical(true));
+        hdu.add_header("BITPIX", FITSValue::Integer(8));
+        hdu.add_header("NAXIS", FITSValue::Integer(0));
+        hdu.headers.push(crate::hdu::headers::FITSHeader::end_hdu());
+        assert!(hdu.validate_primary().is_ok());
+    }
+
+    #[test]
+    fn validate_primary_fails_without_simple() {
+        let mut hdu = HDU::init();
+        hdu.add_header("BITPIX", FITSValue::Integer(8));
+        assert!(hdu.validate_primary().is_err());
+    }
+
+    #[test]
+    fn validate_primary_fails_without_bitpix() {
+        let mut hdu = HDU::init();
+        hdu.add_header("SIMPLE", FITSValue::Logical(true));
+        assert!(hdu.validate_primary().is_err());
+    }
+
+    #[test]
+    fn validate_primary_fails_without_end() {
+        let mut hdu = HDU::init();
+        hdu.add_header("SIMPLE", FITSValue::Logical(true));
+        hdu.add_header("BITPIX", FITSValue::Integer(8));
+        hdu.add_header("NAXIS", FITSValue::Integer(0));
+        // no END keyword added
+        assert!(hdu.validate_primary().is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,50 +1,178 @@
 pub mod hdu;
 pub mod parsing;
 
-/// Return a number indicating how many bytes should be added as padding
-/// to adhere to the FITS specification for a given block of header/data unit.
-/// The FITS spec says that any header/data must be 2880 bytes long or a multiple
-/// of 2880, so if it is less or more than 2880 and is not a multiple of it, the
-/// remaining space must be filled with space chars (62)
-pub fn fill_to_2880(n: i32) -> i32 {
-    let division = n % 2880;
+pub use hdu::HDU;
 
-    let bytes_to_add = match division {
+use std::fs::File;
+use std::io::Write;
+
+/// Return how many padding bytes are needed to align `n` to the next
+/// 2880-byte FITS block boundary.  Returns 0 if `n` is already aligned.
+pub fn fill_to_2880(n: i32) -> i32 {
+    match n % 2880 {
         0 => 0,
         m => 2880 - m,
-    };
-    bytes_to_add
+    }
+}
+
+/// A complete FITS file: an ordered collection of Header Data Units (HDUs).
+///
+/// The first HDU is the primary HDU and must begin with the `SIMPLE` keyword.
+/// Additional HDUs are extensions (IMAGE, BINTABLE, TABLE).
+pub struct FITSFile {
+    pub hdus: Vec<HDU>,
+}
+
+impl FITSFile {
+    pub fn new() -> Self {
+        FITSFile { hdus: Vec::new() }
+    }
+
+    pub fn add_hdu(&mut self, hdu: HDU) {
+        self.hdus.push(hdu);
+    }
+
+    /// Serialize the entire file to a byte vector.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.hdus.iter().flat_map(|h| h.to_bytes()).collect()
+    }
+
+    /// Write the file to `path`, creating or truncating it.
+    pub fn write_to_file(&self, path: &str) -> std::io::Result<()> {
+        let mut file = File::create(path)?;
+        file.write_all(&self.to_bytes())
+    }
+}
+
+/// Utilities for converting between native byte order and the FITS-mandated
+/// big-endian byte order.
+///
+/// FITS always stores multi-byte values (integers, floats) in big-endian order.
+/// On little-endian hosts (e.g. x86) data must be swapped before writing and
+/// after reading.
+pub mod endian {
+    /// Encode `i16` values as big-endian bytes (BITPIX = 16).
+    pub fn i16_to_be_bytes(values: &[i16]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_be_bytes()).collect()
+    }
+
+    /// Encode `i32` values as big-endian bytes (BITPIX = 32).
+    pub fn i32_to_be_bytes(values: &[i32]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_be_bytes()).collect()
+    }
+
+    /// Encode `i64` values as big-endian bytes (BITPIX = 64).
+    pub fn i64_to_be_bytes(values: &[i64]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_be_bytes()).collect()
+    }
+
+    /// Encode `f32` values as big-endian bytes (BITPIX = -32).
+    pub fn f32_to_be_bytes(values: &[f32]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_be_bytes()).collect()
+    }
+
+    /// Encode `f64` values as big-endian bytes (BITPIX = -64).
+    pub fn f64_to_be_bytes(values: &[f64]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_be_bytes()).collect()
+    }
+
+    /// Decode big-endian bytes into `i16` values (BITPIX = 16).
+    pub fn be_bytes_to_i16(bytes: &[u8]) -> Vec<i16> {
+        bytes
+            .chunks_exact(2)
+            .map(|c| i16::from_be_bytes([c[0], c[1]]))
+            .collect()
+    }
+
+    /// Decode big-endian bytes into `i32` values (BITPIX = 32).
+    pub fn be_bytes_to_i32(bytes: &[u8]) -> Vec<i32> {
+        bytes
+            .chunks_exact(4)
+            .map(|c| i32::from_be_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    /// Decode big-endian bytes into `i64` values (BITPIX = 64).
+    pub fn be_bytes_to_i64(bytes: &[u8]) -> Vec<i64> {
+        bytes
+            .chunks_exact(8)
+            .map(|c| i64::from_be_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+            .collect()
+    }
+
+    /// Decode big-endian bytes into `f32` values (BITPIX = -32).
+    pub fn be_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_be_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    /// Decode big-endian bytes into `f64` values (BITPIX = -64).
+    pub fn be_bytes_to_f64(bytes: &[u8]) -> Vec<f64> {
+        bytes
+            .chunks_exact(8)
+            .map(|c| f64::from_be_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+            .collect()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::fill_to_2880;
+    use crate::endian;
 
-    // Assert that if we have a HDU which is 2880 bytes long
-    // we are not going to add any padding
     #[test]
     fn check_2880_bytes_hdu_not_add_any() {
         assert_eq!(fill_to_2880(2880), 0)
     }
 
-    // Assert that if we have a HDU which is 5760 bytes long
-    // we are not going to add any padding (2880 * 2)
     #[test]
     fn check_5760_bytes_hdu_not_add_any() {
         assert_eq!(fill_to_2880(5760), 0)
     }
 
-    // Assert that if we have a HDU which is 2885 bytes long
-    // we are going to add 5 bytes padding
     #[test]
     fn test_2885_bytes_hdu_add_5() {
         assert_eq!(fill_to_2880(2885), 2875)
     }
 
-    // Assert that if we have a HDU which is 1936*1096 bytes long
-    // we are going to add 704 bytes of padding
     #[test]
     fn test_1936_1096_bytes_hdu_not_add_any() {
         assert_eq!(fill_to_2880(1936 * 1096), 704)
+    }
+
+    // --- endian round-trip tests ---
+
+    #[test]
+    fn i16_roundtrip() {
+        let original = vec![0_i16, 1, -1, i16::MAX, i16::MIN];
+        let bytes = endian::i16_to_be_bytes(&original);
+        let decoded = endian::be_bytes_to_i16(&bytes);
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn i32_roundtrip() {
+        let original = vec![0_i32, 1, -1, i32::MAX, i32::MIN];
+        let bytes = endian::i32_to_be_bytes(&original);
+        let decoded = endian::be_bytes_to_i32(&bytes);
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn f32_roundtrip() {
+        let original = vec![0.0_f32, 1.0, -1.0, f32::MAX, f32::MIN_POSITIVE];
+        let bytes = endian::f32_to_be_bytes(&original);
+        let decoded = endian::be_bytes_to_f32(&bytes);
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn f64_roundtrip() {
+        let original = vec![0.0_f64, 1.0, -1.0, f64::MAX, f64::MIN_POSITIVE];
+        let bytes = endian::f64_to_be_bytes(&original);
+        let decoded = endian::be_bytes_to_f64(&bytes);
+        assert_eq!(original, decoded);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,15 @@
 use rfitsio::parsing::parse;
 
 fn main() -> std::io::Result<()> {
-    parse("./FOCx38i0101t_c0f.fits")?;
+    let fits = parse("./FOCx38i0101t_c0f.fits")?;
+    println!("Parsed {} HDU(s)", fits.hdus.len());
+    for (i, hdu) in fits.hdus.iter().enumerate() {
+        println!(
+            "  HDU {}: {} header record(s), {} data byte(s)",
+            i,
+            hdu.headers.len(),
+            hdu.raw_data().len()
+        );
+    }
     Ok(())
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -1,46 +1,147 @@
 use std::fs::File;
 use std::io::prelude::*;
-use std::io::{BufReader, Seek};
+use std::io::{BufReader, Seek, SeekFrom};
 
-pub fn parse(img_path: &str) -> std::io::Result<()> {
+use crate::fill_to_2880;
+use crate::hdu::data::FITSData;
+use crate::hdu::headers::FITSHeader;
+use crate::hdu::HDU;
+use crate::FITSFile;
+
+/// Parse a FITS file at `img_path` and return a `FITSFile` containing all HDUs.
+///
+/// Spec compliance:
+/// - Header records are read in 80-byte chunks until the `END` keyword is found.
+/// - After the last header record the reader is advanced to the next 2880-byte
+///   boundary before the data unit begins.
+/// - The data unit size is computed from the parsed `BITPIX` and `NAXISn` values:
+///   `|BITPIX|/8 × NAXIS1 × NAXIS2 × … × NAXISn`.
+/// - After the data unit the reader is again aligned to the next 2880-byte
+///   boundary for the following HDU.
+/// - All HDUs in the file are read (not just the first one).
+pub fn parse(img_path: &str) -> std::io::Result<FITSFile> {
     let f = File::open(img_path)?;
     let mut reader = BufReader::new(f);
-    let before = reader.stream_position()?;
-    let mut header = [0; 80];
+    let mut fits_file = FITSFile::new();
 
-    while &header[0..3] != b"END" {
-        reader.read_exact(&mut header)?;
-        println!("header: {:?}", &header);
-        println!("{}", std::str::from_utf8(&header).unwrap());
+    loop {
+        // ── Read header records ────────────────────────────────────────────
+
+        let header_start = reader.stream_position()?;
+        let mut headers: Vec<FITSHeader> = Vec::new();
+        let mut record = [0u8; 80];
+
+        // Values needed to compute the data unit size.
+        let mut bitpix: i32 = 0;
+        let mut naxis: usize = 0;
+        // naxisn[0] = NAXIS1, naxisn[1] = NAXIS2, …
+        let mut naxisn: Vec<usize> = Vec::new();
+
+        loop {
+            match reader.read_exact(&mut record) {
+                Ok(_) => {}
+                Err(_) => break,
+            }
+
+            let keyword = std::str::from_utf8(&record[0..8])
+                .unwrap_or("")
+                .trim_end();
+
+            // Parse scalar keywords needed for data-unit sizing.
+            // Values occupy bytes 11–30 of the record (positions 10–29).
+            if record[8] == b'=' {
+                let raw = std::str::from_utf8(&record[10..80]).unwrap_or("");
+                // Strip any inline comment after ` / `.
+                let val_str = raw.split('/').next().unwrap_or("").trim();
+
+                match keyword {
+                    "BITPIX" => {
+                        bitpix = val_str.parse().unwrap_or(0);
+                    }
+                    "NAXIS" => {
+                        naxis = val_str.parse().unwrap_or(0);
+                        naxisn = vec![0; naxis];
+                    }
+                    k if k.starts_with("NAXIS") => {
+                        if let Ok(axis_idx) = k[5..].parse::<usize>() {
+                            if axis_idx >= 1 && axis_idx <= naxis {
+                                naxisn[axis_idx - 1] = val_str.parse().unwrap_or(0);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            let is_end = &record[0..3] == b"END";
+            headers.push(FITSHeader::new_raw(&record[0..10], &record[10..80]));
+
+            if is_end {
+                break;
+            }
+        }
+
+        if headers.is_empty() {
+            break;
+        }
+
+        // ── Align to the next 2880-byte boundary after headers ─────────────
+        //
+        // The header section occupies an integer number of 2880-byte blocks.
+        // We may have read a non-multiple number of 80-byte records, so skip
+        // the remaining bytes in the current block.
+
+        let bytes_read_so_far = (reader.stream_position()? - header_start) as i32;
+        let header_padding = fill_to_2880(bytes_read_so_far) as i64;
+        if header_padding > 0 {
+            reader.seek(SeekFrom::Current(header_padding))?;
+        }
+
+        // ── Compute data unit size ─────────────────────────────────────────
+        //
+        // data_size = |BITPIX|/8 × NAXIS1 × NAXIS2 × … × NAXISn
+        // If NAXIS = 0 there is no data unit.
+
+        let data_size: usize = if naxis == 0 || naxisn.is_empty() {
+            0
+        } else {
+            let pixel_count: usize = naxisn.iter().product();
+            let bytes_per_pixel = (bitpix.unsigned_abs() / 8) as usize;
+            pixel_count * bytes_per_pixel
+        };
+
+        // ── Read the data unit ─────────────────────────────────────────────
+
+        let mut raw_data = vec![0u8; data_size];
+        if data_size > 0 {
+            reader.read_exact(&mut raw_data)?;
+            // Align past the data block padding.
+            let data_padding = fill_to_2880(data_size as i32) as i64;
+            if data_padding > 0 {
+                reader.seek(SeekFrom::Current(data_padding))?;
+            }
+        }
+
+        // ── Build the HDU ──────────────────────────────────────────────────
+
+        let mut hdu = HDU::init();
+        hdu.headers = headers;
+        // Store raw bytes directly; callers use crate::endian to decode them.
+        hdu.data = FITSData { data: raw_data };
+        fits_file.add_hdu(hdu);
+
+        // ── Check whether another HDU follows ─────────────────────────────
+
+        let mut peek = [0u8; 1];
+        match reader.read_exact(&mut peek) {
+            Err(_) => break, // EOF
+            Ok(_) => {
+                // Un-consume the byte so the next iteration reads it as part of
+                // the next HDU's header.
+                reader.seek(SeekFrom::Current(-1))?;
+            }
+        }
     }
 
-    let after_headers = reader.stream_position()?;
-    let mut _buf = Vec::new();
-
-    println!("The HDU was {} bytes long", &after_headers - &before);
-
-    reader.read_until(0, &mut _buf)?;
-
-    let after_headers_2 = reader.stream_position()?;
-
-    println!("After header we are at {}", &after_headers_2 - &before);
-
-    // we are done reading HEADERS, fetch now pixel data
-    //let mut image: [u8; 1024*1024]  = [0; 1024 * 1024];
-    let mut image: [u8; 1936 * 1096 - 1] = [0; 1936 * 1096 - 1];
-    reader.read_exact(&mut image)?;
-
-    let after_image = reader.stream_position()?;
-
-    println!(
-        "The Image was {} bytes long",
-        &after_image - &after_headers_2
-    );
-
-    // next HDU
-    let mut hdu: Vec<u8> = Vec::new();
-    let size = reader.read_to_end(&mut hdu)?;
-    println!("Read {} bytes", size);
-    //println!("Remaining {}", std::str::from_utf8(&hdu[0..80]).unwrap());
-    Ok(())
+    Ok(fits_file)
 }


### PR DESCRIPTION
- headers: FITSValue enum with proper value encoding (integers and logicals right-justified in cols 11-30, strings single-quoted and padded to 8 chars, floats in scientific notation)
- headers: keyword validation (uppercase A-Z, 0-9, hyphen, underscore)
- headers: prevent END/COMMENT/HISTORY via new(); add comment() and history() constructors with no = indicator
- headers: new_with_comment() for inline comment after ' / '
- hdu: make all methods pub; add add_comment(), add_history(), add_header_with_comment()
- hdu: to_bytes() serialises header section (space-padded to 2880-byte boundary) followed by data unit (already null-padded)
- hdu: validate_primary() checks SIMPLE first, BITPIX present, NAXIS present, END last
- data: typed add_u8/i16/i32/i64/f32/f64 helpers that store values in FITS big-endian byte order
- lib: FITSFile struct (Vec<HDU>) with to_bytes() and write_to_file()
- lib: endian module with to/from big-endian helpers for all BITPIX types
- parsing: fix 2880-byte alignment after header section
- parsing: BITPIX-aware data unit size calculation (|BITPIX|/8 * prod NAXISn)
- parsing: multi-HDU loop; returns FITSFile instead of printing
- main: updated to print HDU count and sizes